### PR TITLE
Add NetworkX version information

### DIFF
--- a/2023-round-2/axif0/nx_version.txt
+++ b/2023-round-2/axif0/nx_version.txt
@@ -1,0 +1,1 @@
+Installed networkx version in my device is - 3.1


### PR DESCRIPTION
This PR addresses the first task - [Issue #2](https://github.com/networkx/outreachy/issues/2). 

Changes made:
- Installed NetworkX locally and verified its import in the Python environment.
- Created a new folder named after my GitHub username in the `2023-round-2` directory.
- Added a file `nx_version.txt` containing the version of NetworkX installed.