### PR TITLE
Added nx_version.txt with NetworkX version

### DIFF
--- a/2023-round-2/your-github-username/aparajitaks/nx_version.txt
+++ b/2023-round-2/your-github-username/aparajitaks/nx_version.txt
@@ -1,0 +1,1 @@
+<networkx-version>


### PR DESCRIPTION
This Pull Request adds a new file, nx_version.txt, that contains the version of NetworkX being used. The file is located in the 2023-round-2/your-github-username/aparajitaks/ directory.
This addition helps in tracking the specific version of NetworkX used during the project.

